### PR TITLE
fix(scylla.yaml): Do not set skip_wait_for_gossip_to_settle to 0

### DIFF
--- a/resources/scylla.yaml
+++ b/resources/scylla.yaml
@@ -501,8 +501,8 @@ auto_bootstrap: true
 
 # Try to speed up cluster formation
 ring_delay_ms: 3000
-# skip_wait_for_gossip_to_settle: 5
-skip_wait_for_gossip_to_settle: 0
+skip_wait_for_gossip_to_settle: 5
+# skip_wait_for_gossip_to_settle: 0
 # When we concurrently restart nodes, they'll lock up on boot for 300 seconds
 # by default.
 shadow_round_ms: 1000


### PR DESCRIPTION
In issue [2441](https://github.com/scylladb/scylla-enterprise/issues/2441) we suspect that this started causing jepsen tests to fail.

This job proves that this PR fixes the issue:
https://jenkins.scylladb.com/job/enterprise-2022.2/job/longevity/job/Reproducers/job/jepsen-test-all-not-skipping-gossip/4/