### PR TITLE
set force_schema_commit_log: true

### DIFF
--- a/resources/scylla.yaml
+++ b/resources/scylla.yaml
@@ -506,3 +506,6 @@ skip_wait_for_gossip_to_settle: 0
 # When we concurrently restart nodes, they'll lock up on boot for 300 seconds
 # by default.
 shadow_round_ms: 1000
+
+# this is needed since `consistent_cluster_management` is enabled by default in 5.2/2023.1
+force_schema_commit_log: true


### PR DESCRIPTION
Since `consistent_cluster_management` is enabled by default since 5.2/2023.1 we also need to enable `force_schema_commit_log` otherwise scylla won't boot.

and since jepsen test isn't taking the default scylla.yaml, so some of the defaults are not available (some default only goes to scylla yaml case of upgrade cases)