### PR TITLE
replace jsch with a fork

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,10 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [org.clojure/java.jmx "0.3.1"]
-                 [jepsen "0.2.1" :exclusions [org.slf4j/slf4j-api]]
+                 [com.github.mwiede/jsch "0.2.18"]
+                 [jepsen "0.2.4" :exclusions [org.slf4j/slf4j-api
+                                              com.jcraft/jsch
+                                              com.jcraft/jsch.agentproxy.core]]
                  [cc.qbits/alia "4.3.3" :exclusions [com.datastax.cassandra/cassandra-driver-core
                                                      com.datastax.cassandra:dse-driver]]
                  [cc.qbits/hayt "4.1.0"]


### PR DESCRIPTION
since the original tool only support RSA keys,
which are now disabled by default from openssh 8.8

Ref: https://www.openssh.com/txt/release-8.8
Ref: https://github.com/mwiede/jsch

### Testing
- [x] 🟢  https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/jepsen-test-all/14/

